### PR TITLE
removing the .min from the bower.main file identifier. 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "angular-http-batcher",
   "version": "1.7.0",
   "description": "Enables transparent HTTP batch requests with Angular",
-  "main": "dist/angular-http-batch.min.js",
+  "main": "dist/angular-http-batch.js",
   "keywords": [
     "angularjs",
     "angular",


### PR DESCRIPTION
Using '.min' prevents plugins like gulp-sourcemaps from providing a clean mapping of source files. See examples at https://www.npmjs.com/package/gulp-sourcemaps