### PR TITLE
Update httpAdapter.js

### DIFF
--- a/src/services/adapters/httpAdapter.js
+++ b/src/services/adapters/httpAdapter.js
@@ -53,7 +53,7 @@ function HttpBatchAdapter($document, $window, httpBatchConfig) {
 
       batchBody.push('Content-Type: application/http; msgtype=request', constants.emptyString);
 
-      batchBody.push(request.method + ' ' + urlInfo.relativeUrl + ' ' + constants.httpVersion);
+      batchBody.push(request.method + ' ' + encodeURI(urlInfo.relativeUrl) + ' ' + constants.httpVersion);
       batchBody.push('Host: ' + urlInfo.host);
 
       for (header in request.headers) {


### PR DESCRIPTION
Use encodeURI to process query strings with spaces and other such characters.
batchBody.push(request.method + ' ' + encodeURI(urlInfo.relativeUrl) + ' ' + constants.httpVersion);