### PR TITLE
Handle multiple JSON Vulnerability Prefixes in same response

### DIFF
--- a/src/services/adapters/httpAdapter.js
+++ b/src/services/adapters/httpAdapter.js
@@ -177,11 +177,22 @@ function HttpBatchAdapter($document, $window, httpBatchConfig) {
     return boundary;
   }
 
+  /**
+   * see https://docs.angularjs.org/api/ng/service/$http#json-vulnerability-protection
+   * @param data
+   * @returns {*|void|string}
+   */
+  function trimJsonProtectionVulnerability(data) {
+    return typeof (data) === 'string' ? data.replace(')]}\',\n', '') : data;
+  }
+
   function convertDataToCorrectType(contentType, dataStr) {
     var data = dataStr;
     contentType = contentType.toLowerCase();
 
     if (contentType.indexOf('json') > -1) {
+      // only remove json vulnerability prefix if we're parsing json
+      dataStr = trimJsonProtectionVulnerability(dataStr);
       data = angular.fromJson(dataStr);
     }
 

--- a/src/services/httpBatcher.js
+++ b/src/services/httpBatcher.js
@@ -34,15 +34,6 @@ function addRequestFn(request) {
   return true;
 }
 
-/**
- * see https://docs.angularjs.org/api/ng/service/$http#json-vulnerability-protection
- * @param data
- * @returns {*|void|string}
- */
-function trimJsonProtectionVulnerability(data) {
-  return typeof (data) === 'string' ? data.replace(')]}\',\n', '') : data;
-}
-
 function sendFn() {
   var self = this,
     adapter = self.getAdapter(),
@@ -50,11 +41,7 @@ function sendFn() {
 
   self.sendCallback();
   self.$injector.get('$http')(httpBatchConfig).then(function (response) {
-    var batchResponses;
-
-    response.data = trimJsonProtectionVulnerability(response.data);
-
-    batchResponses = adapter.parseResponse(self.requests, response, self.config);
+    var batchResponses = adapter.parseResponse(self.requests, response, self.config);
 
     angular.forEach(batchResponses, function (batchResponse) {
       batchResponse.request.callback(


### PR DESCRIPTION
An error ("Unable to parse JSON string") occurs when the same batch
response contains multiple JSON vulnerability prefixes (such as when
multiple GET operations that return arrays are batched).  A unit test
was added to illustrate this scenario.

This occurred only with multiple prefixes because string.replace was
used on the entire response text, and string.replace only replaces the
first occurrence of the substring.

To fix this, I moved the trim function to the "httpAdapter", because
that allowed finer control over when the prefix was trimmed - the prefix
is now trimmed for each batch response separately and only when parsing
a response with a 'json' content type.  Further, trimming JSON
vulnerability prefixes don't appear relevant for multifetch:  the
returned data is in an object form, not an array - so the vulnerability
does not apply (see this for more details of how the vulnerability
manifests:
http://haacked.com/archive/2008/11/20/anatomy-of-a-subtle-json-vulnerability.aspx/
).